### PR TITLE
Fix VoWiFi MNC detection using SIM EF_AD

### DIFF
--- a/ThirdParty/vowifi-go/cmd/celldock-vowifi-runtime/main.go
+++ b/ThirdParty/vowifi-go/cmd/celldock-vowifi-runtime/main.go
@@ -117,6 +117,12 @@ func run(cfg config) error {
 	if err != nil {
 		return store.fail("sim", fmt.Errorf("read IMEI: %w", err))
 	}
+	profile, err := readSIMProfile(transport, imsi, imei)
+	if err != nil {
+		// Some modems/cards do not expose EF_AD through CRSM. Preserve the
+		// existing fallback in that case, but make the missing evidence visible.
+		fmt.Fprintf(os.Stderr, "SIM MNC length unavailable: %v; using IMSI-derived PLMN\n", err)
+	}
 	aka := simauth.NewAKAProvider(transport)
 	simAdapter := runtimehost.NewReaderSIMAdapter(&simWithIMSI{AKAProvider: aka, imsi: imsi})
 	defer simAdapter.Close()
@@ -124,11 +130,8 @@ func run(cfg config) error {
 	access := runtimehost.NewModemAccessAdapter(modem)
 	prepared, err := identity.PrepareStart(identity.PrepareStartInput{
 		DeviceID: cfg.OuterInterface + "-imei-" + imei,
-		Profile: identity.Profile{
-			IMSI: imsi,
-			IMEI: imei,
-		},
-		Access: access,
+		Profile:  profile,
+		Access:   access,
 	})
 	if err != nil {
 		return store.fail("identity", fmt.Errorf("prepare carrier identity: %w", err))

--- a/ThirdParty/vowifi-go/cmd/celldock-vowifi-runtime/sim_identity.go
+++ b/ThirdParty/vowifi-go/cmd/celldock-vowifi-runtime/sim_identity.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/boa-z/vowifi-go/runtimehost/identity"
+	"github.com/boa-z/vowifi-go/runtimehost/simauth"
+	"github.com/boa-z/vowifi-go/runtimehost/simtransport"
+)
+
+// readSIMProfile uses the home SIM's EF_AD, not the serving network, to split
+// the already-read IMSI. Its total length cannot distinguish a two-digit MNC
+// from a three-digit MNC. On error, the returned profile retains the previous
+// IMSI-only fallback so cards without accessible EF_AD keep their old behavior.
+func readSIMProfile(transport *simtransport.Adapter, imsi, imei string) (identity.Profile, error) {
+	profile := identity.Profile{IMSI: imsi, IMEI: imei}
+	// 3GPP TS 31.102: EF_AD (6FAD), byte 4, low nibble is the MNC length.
+	ad, err := transport.ReadCRSMBinary(0x6FAD, 0, 4, "")
+	if err != nil {
+		return profile, fmt.Errorf("read EF_AD: %w", err)
+	}
+	if !ad.Success() {
+		return profile, fmt.Errorf("read EF_AD: SW=%s", ad.StatusString())
+	}
+	data, err := hex.DecodeString(ad.Data)
+	if err != nil {
+		return profile, fmt.Errorf("decode EF_AD: %w", err)
+	}
+	mncLength, ok := simauth.MNCLengthFromAD(data)
+	if !ok {
+		return profile, errors.New("EF_AD has no valid MNC length")
+	}
+	if len(imsi) < 3+mncLength {
+		return profile, errors.New("IMSI is shorter than the SIM's PLMN")
+	}
+	profile.MCC = imsi[:3]
+	profile.MNC = imsi[3 : 3+mncLength]
+	return profile, nil
+}

--- a/ThirdParty/vowifi-go/cmd/celldock-vowifi-runtime/sim_identity_test.go
+++ b/ThirdParty/vowifi-go/cmd/celldock-vowifi-runtime/sim_identity_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/boa-z/vowifi-go/runtimehost/identity"
+	"github.com/boa-z/vowifi-go/runtimehost/simtransport"
+)
+
+type simIdentityAT struct {
+	calls    []string
+	response string
+	err      error
+}
+
+func (a *simIdentityAT) ExecuteATSilent(cmd string, _ time.Duration) (string, error) {
+	a.calls = append(a.calls, cmd)
+	return a.response, a.err
+}
+
+func TestReadSIMProfileUsesADForEPDGAndIMSIdentity(t *testing.T) {
+	// Synthetic IMSI: with a two-digit MNC the first subscriber digit is 6.
+	const imsi = "262036000000001"
+	const imei = "490154203237518"
+	for _, tt := range []struct {
+		name, ad, mnc, paddedMNC string
+	}{
+		{"two-digit MNC", "01000102", "03", "003"},
+		{"three-digit MNC", "01000103", "036", "036"},
+		{"RFU high nibble", "010001F2", "03", "003"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			at := &simIdentityAT{response: `+CRSM: 144,0,"` + tt.ad + `"` + "\r\nOK\r\n"}
+			profile, err := readSIMProfile(simtransport.NewAdapter(at), imsi, imei)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if profile != (identity.Profile{IMSI: imsi, IMEI: imei, MCC: "262", MNC: tt.mnc}) {
+				t.Fatalf("profile = %+v", profile)
+			}
+			if !reflect.DeepEqual(at.calls, []string{"AT+CRSM=176,28589,0,0,4"}) {
+				t.Fatalf("AT calls = %v", at.calls)
+			}
+			prepared, err := identity.PrepareStart(identity.PrepareStartInput{Profile: profile})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := "epdg.epc.mnc" + tt.paddedMNC + ".mcc262.pub.3gppnetwork.org"; prepared.EPDGAddr != want {
+				t.Fatalf("ePDG = %q, want %q", prepared.EPDGAddr, want)
+			}
+			realm := "ims.mnc" + tt.paddedMNC + ".mcc262.3gppnetwork.org"
+			if prepared.IMSIdentity.Domain != realm || prepared.IMSIdentity.IMPI != imsi+"@"+realm ||
+				prepared.IMSIdentity.IMPU != "sip:"+imsi+"@"+realm {
+				t.Fatalf("IMS identity = %+v, want realm %q", prepared.IMSIdentity, realm)
+			}
+			naiRealm := "nai.epc.mnc" + tt.paddedMNC + ".mcc262.3gppnetwork.org"
+			if prepared.CarrierPolicy.IMS.NAIRealm != naiRealm ||
+				!strings.HasSuffix(prepared.CarrierPolicy.IMS.PermanentNAI, "@"+naiRealm) {
+				t.Fatalf("NAI = %q, want realm %q", prepared.CarrierPolicy.IMS.PermanentNAI, naiRealm)
+			}
+		})
+	}
+}
+
+func TestReadSIMProfilePreservesFallbackWhenADIsUnavailable(t *testing.T) {
+	const imsi = "262036000000001"
+	for _, tt := range []struct {
+		name, response, wantError string
+		err                       error
+	}{
+		{name: "transport error", err: errors.New("bridge unavailable"), wantError: "read EF_AD"},
+		{name: "unsupported AT command", response: "ERROR", wantError: "read EF_AD"},
+		{name: "missing file", response: `+CRSM: 106,130,""`, wantError: "SW=6A82"},
+		{name: "short EF", response: `+CRSM: 144,0,"010001"`, wantError: "no valid MNC length"},
+		{name: "invalid length", response: `+CRSM: 144,0,"01000104"`, wantError: "no valid MNC length"},
+		{name: "unset length", response: `+CRSM: 144,0,"010001FF"`, wantError: "no valid MNC length"},
+		{name: "malformed data", response: `+CRSM: 144,0,"XYZ"`, wantError: "read EF_AD"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			at := &simIdentityAT{response: tt.response, err: tt.err}
+			profile, err := readSIMProfile(simtransport.NewAdapter(at), imsi, "")
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("error = %v, want %q", err, tt.wantError)
+			}
+			if profile != (identity.Profile{IMSI: imsi}) {
+				t.Fatalf("fallback profile = %+v", profile)
+			}
+		})
+	}
+}
+
+func TestReadSIMProfileRejectsShortIMSIWithoutSlicing(t *testing.T) {
+	at := &simIdentityAT{response: `+CRSM: 144,0,"01000103"`}
+	profile, err := readSIMProfile(simtransport.NewAdapter(at), "26203", "")
+	if err == nil || profile.MCC != "" || profile.MNC != "" {
+		t.Fatalf("profile = %+v, error = %v", profile, err)
+	}
+}


### PR DESCRIPTION
## Problem

CellDock starts the VoWiFi runtime with an IMSI and IMEI but no explicit home MCC/MNC. The identity fallback takes `imsi[3:6]` for a normal-length IMSI, so a two-digit MNC can accidentally include the first subscriber digit.

On an O2 Germany SIM, the masked IMSI prefix `262036…` must be split as `262 / 03 / 6…`. A read-only `AT+CRSM=176,28589,0,0,4` query returned `+CRSM: 144,0,"01000102"`: EF_AD byte 4 specifies a two-digit MNC. CellDock 0.3.1 (build 105) instead requested `epdg.epc.mnc036.mcc262.pub.3gppnetwork.org`, which resolved to `127.0.0.1` and resulted in an IKE response timeout. The expected home-network ePDG is `epdg.epc.mnc003.mcc262.pub.3gppnetwork.org`.

## Change

- Read the first four bytes of the home SIM's EF_AD before `identity.PrepareStart` and reuse the existing `simauth.MNCLengthFromAD` parser.
- Pass the explicit MCC and native-width MNC into the existing identity/carrier pipeline so ePDG, IMS identities and the permanent NAI realm use the same PLMN. Do not use the serving/roaming network or hard-code an O2 exception.
- If CRSM/EF_AD is unavailable or invalid, emit a diagnostic and retain the previous IMSI-only fallback rather than making EF_AD support a new startup requirement. This fallback remains heuristic; the patch fixes the path where the SIM provides a valid length.
- Add synthetic regression cases for two- and three-digit MNCs, RFU high bits, ePDG/IMS/NAI derivation, transport and SIM-status errors, short/malformed/unset EF_AD, and short IMSIs.

No public runtime API, configuration format, dependency, proxy setting or Swift bridge permission is changed. The existing SIM bridge already permits the read-only CRSM command.

## Validation

On macOS arm64 with Go 1.26.8, from `ThirdParty/vowifi-go`:

- `go test -count=1 ./...` — passed, all 17 packages.
- `go vet ./...` — passed.
- The runtime package was rerun after adding the permanent NAI assertion — passed.
- `gofmt` on all changed Go files and `git diff --check` — passed.

The required `make ci` entry point was attempted but the system Make does not support `.RECIPEPREFIX`. Invoking `scripts/ci.sh` directly then stopped at `mapfile`, which the system Bash does not provide. The wrapper suite is therefore not claimed as passing; the Go tests and vet above were run directly. No separate VoHive checkout was used; changes are confined to CellDock's runtime command.

The original SIM's EF_AD and failing ePDG were verified on hardware. The patched runtime has **not** been installed or tested for live O2 IKE/AKA/IMS registration, so this PR does not claim end-to-end VoWiFi success. All complete subscriber identifiers in tests are synthetic; no complete real IMSI/ICCID is included.

Reference: [3GPP TS 31.102, EF_AD](https://www.etsi.org/deliver/etsi_ts/131100_131199/131102/19.04.00_60/ts_131102v190400p.pdf).
